### PR TITLE
Ajouter le support de VRT NU

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sur **Kodi** :
   Instagram, torrents¹, magnets¹ et Ace Stream¹, AlloCiné, Arte, BitChute,
   Dailymotion¹, DevTube¹, Dumpert¹, Facebook, Flickr, Full30, Gamekult¹,
   JeuxVideoCom, LiveLeak, PeerTube, Первый канал, Rutube, Steam, StormoTV,
-  Útvarp Saga, YT Home…
+  Útvarp Saga, YT Home, VRT NU¹…
 - des musiques : liens directs (*mp3*, *flac*…), SoundCloud¹ et Apple Podcasts,
   Arte Radio, Blog Talk Radio, France Inter, KCAA Radio, Mixcloud¹, My Cloud
   Player, Pippa, podCloud, Radioline…
@@ -56,8 +56,9 @@ installer les extensions
 magnets), [Plexus](https://github.com/tvaddonsco/program.plexus) (Ace Stream),
 [DailyMotion.com](https://kodi.tv/addon/plugins-video-add-ons/dailymotioncom),
 [Dumpert](https://kodi.tv/addon/plugins-video-add-ons/dumpert),
-[SoundCloud](https://kodi.tv/addon/music-add-ons-plugins/soundcloud) ou
-[Mixcloud](https://kodi.tv/addon/music-add-ons-plugins/mixcloud) dans Kodi.
+[SoundCloud](https://kodi.tv/addon/music-add-ons-plugins/soundcloud)
+[Mixcloud](https://kodi.tv/addon/music-add-ons-plugins/mixcloud) ou
+[VRT NU](https://kodi.tv/addon/plugins-video-add-ons/vrt-nu-0) dans Kodi.
 
 ## Licence
 

--- a/src/core/scraper/vrtnu.js
+++ b/src/core/scraper/vrtnu.js
@@ -1,0 +1,33 @@
+/**
+ * @module
+ */
+
+/**
+ * L'URL de l'extension pour lire des vidéos issues de VrtNu (https://vrtnu.be).
+ *
+ * @constant {string}
+ */
+const PLUGIN_URL = "plugin://plugin.video.vrt.nu/play/";
+
+/**
+ * Les règles avec les patrons et leur action.
+ *
+ * @constant {Map.<(Array.<string>|string), Function>}
+ */
+export const rules = new Map();
+
+/**
+ * Extrait les informations nécessaire pour lire une vidéo / playlist sur Kodi.
+ *
+ * @function action
+ * @param {URL}             url              L'URL d'une vidéo / playlist
+ *                                           YouTube (ou Invidious / HookTube).
+ * @param {URLSearchParams} url.searchParams Les paramètres de l'URL.
+ * @returns {Promise} Une promesse contenant le lien du <em>fichier</em> ou
+ *                    <code>null</code>.
+ */
+rules.set("*://*.vrt.be/vrtnu/a-z/*", function ({ pathname }) {
+    if (pathname.length <= 11) return null;
+    if (pathname.substring(0,11) != "/vrtnu/a-z/") return null;
+    return PLUGIN_URL + 'url/https://vrt.be' + pathname;
+});

--- a/src/core/scrapers.js
+++ b/src/core/scrapers.js
@@ -33,6 +33,7 @@ import { rules as stormotv }       from "./scraper/stormotv.js";
 import { rules as torrent }        from "./scraper/torrent.js";
 import { rules as twitch }         from "./scraper/twitch.js";
 import { rules as vimeo }          from "./scraper/vimeo.js";
+import { rules as vrtnu }        from "./scraper/vrtnu.js";
 import { rules as youtube }        from "./scraper/youtube.js";
 
 /**
@@ -45,7 +46,7 @@ const scrapers = [
     dailymotion, facebook, flickr, full30, gamekult, instagram, jeuxvideocom,
     kcaastreaming, mixcloud, mycloudplayers, onetv, peertube, pippa, podcloud,
     radioline, rutube, soundcloud, steampowered, stormotv, twitch, vimeo,
-    youtube, torrent, acestream, generics
+    youtube, torrent, acestream, generics, vrtnu
 ];
 
 /**

--- a/test/core/scraper/vrtnu.js
+++ b/test/core/scraper/vrtnu.js
@@ -1,0 +1,63 @@
+import assert from "assert";
+import { URL } from "url";
+import { extract } from "../../../src/core/scrapers.js";
+import { rules } from "../../../src/core/scraper/vrtnu.js";
+
+describe("scraper/vrtnu", function () {
+    describe("#patterns", function () {
+        it("should return the URL when it's a unsupported URL", function () {
+            const url = "https://www.vrt.be/vrtnu/livestream";
+            return extract(url).then(function (file) {
+                assert.strictEqual(file, url);
+            });
+        });
+    });
+
+    describe("*://*.vrt.be/vrtnu/a-z/*", function () {
+        let action;
+
+        before(function () {
+            action = rules.get(this.test.parent.title);
+        });
+
+        it("should return null when it's a-z view", function () {
+            const url = "https://www.vrt.be/vrtnu/a-z/";
+            const expected = null;
+
+            const file = action(new URL(url));
+            assert.strictEqual(file, expected);
+        });
+
+        it("should return null when it's not a video", function () {
+            const url = "https://www.vrt.be/vrtnu/livestream/";
+            const expected = null;
+
+            const file = action(new URL(url));
+            assert.strictEqual(file, expected);
+        });
+
+        it("should return video id", function () {
+            const url = "https://www.vrt.be/vrtnu/a-z/woodstock/2019/woodstock/";
+            const expected = "plugin://plugin.video.vrt.nu/play/url/https://vrt.be/vrtnu/a-z/woodstock/2019/woodstock/";
+
+            const file = action(new URL(url));
+            assert.strictEqual(file, expected);
+        });
+
+        it("should return video id when protocol is HTTP", function () {
+            const url = "http://www.vrt.be/vrtnu/a-z/just-another-immigrant/1/just-another-immigrant-s1a1/";
+            const expected = "plugin://plugin.video.vrt.nu/play/url/https://vrt.be/vrtnu/a-z/just-another-immigrant/1/just-another-immigrant-s1a1/";
+
+            const file = action(new URL(url));
+            assert.strictEqual(file, expected);
+        });
+
+        it("should return video id withoud www prefix", function () {
+            const url = "https://vrt.be/vrtnu/a-z/ennemi-public/1/ennemi-public-s1a1-la-brebis-egaree/";
+            const expected = "plugin://plugin.video.vrt.nu/play/url/https://vrt.be/vrtnu/a-z/ennemi-public/1/ennemi-public-s1a1-la-brebis-egaree/";
+
+            const file = action(new URL(url));
+            assert.strictEqual(file, expected);
+        });
+    });
+});


### PR DESCRIPTION
This PR adds support for VRT NU, a belgian video platform.
To play the videos the [kodi plugin](https://kodi.tv/addon/plugins-video-add-ons/vrt-nu-0) for VRT NU must be installed.
This PR is tested with the latest version (2.2.1) of the VRT NU plugin.
