### PR TITLE
player: Avoid getting properties from unavailable player

### DIFF
--- a/src/core/jsonrpc/player.js
+++ b/src/core/jsonrpc/player.js
@@ -66,7 +66,7 @@ export const Player = class {
         const players = await this.kodi.send("Player.GetActivePlayers");
         // Ne pas demander les propriétés du lecteur vidéo quand un autre
         // lecteur est actif. https://github.com/xbmc/xbmc/issues/17897
-        if (0 === players.length || players.some((p) => 1 === p.playerid)) {
+        if (players.some((p) => 1 === p.playerid)) {
             const results = await this.kodi.send("Player.GetProperties", {
                 playerid: 1,
                 properties,

--- a/test/unit/core/jsonrpc/player.js
+++ b/test/unit/core/jsonrpc/player.js
@@ -27,23 +27,17 @@ describe("core/jsonrpc/player.js", function () {
             const properties = ["foo", "baz", "quz", "time", "totaltime"];
             const result = await player.getProperties(properties);
             assert.deepStrictEqual(result, {
-                foo:       "bar",
-                baz:       42,
-                qux:       true,
-                time:      3723,
+                position:  -1,
+                repeat:    "off",
+                shuffled:  false,
+                speed:     0,
+                time:      0,
                 totaltime: 0,
             });
 
-            assert.strictEqual(fake.callCount, 2);
+            assert.strictEqual(fake.callCount, 1);
             assert.deepStrictEqual(fake.firstCall.args, [
                 "Player.GetActivePlayers",
-            ]);
-            assert.deepStrictEqual(fake.secondCall.args, [
-                "Player.GetProperties",
-                {
-                    playerid:   1,
-                    properties: ["foo", "baz", "quz", "time", "totaltime"],
-                },
             ]);
         });
 
@@ -118,7 +112,7 @@ describe("core/jsonrpc/player.js", function () {
             const fake = sinon.fake((method) => {
                 switch (method) {
                     case "Player.GetActivePlayers":
-                        return Promise.resolve([]);
+                        return Promise.resolve([{ playerid: 1 }]);
                     case "Player.GetProperties":
                         return Promise.resolve({ foo: "bar" });
                     default:


### PR DESCRIPTION
It makes no sense asking for playerid=1 if it doesn't exist.
Furthermore, it makes Kodi return:
"""
{"error":{"code":-32100,"message":"Failed to execute method."},"id":2,"jsonrpc":"2.0"}
"""
which makes the entire context menu fail and show only an error.

Fixes: https://github.com/regseb/castkodi/issues/34