### PR TITLE
feat: Ajouter le support de VTM GO

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ des vidéos et des musiques sur **Kodi** :
   Radio, Radioline, Steam, Streamable, TikTok, Ultimedia, Veoh, VideoPress,
   Viously ;
   - Allemagne : Arte ;
-  - Belgique : VRT NU ;
+  - Belgique : VRT NU, VTM GO ;
   - États-Unis : KCAA Radio ;
   - France : 20 Minutes, AlloCiné, Arte, Arte Radio, France Inter, Futura
     Sciences, Gamekult, JeuxVideoCom, Konbini, Le Point, L'Internaute, Melty,

--- a/locales/en/amo_description.html
+++ b/locales/en/amo_description.html
@@ -7,9 +7,9 @@ Cast&nbsp;Kodi, as the name suggests, adds the ability to cast videos and music 
     YouTube, Twitch, Vimeo, SoundCloud as well as Ace&nbsp;Stream, Apple&nbsp;Podcasts, Bigo&nbsp;Live, BitChute, Blog&nbsp;Talk&nbsp;Radio, Castbox, Dailymotion, DevTube, Facebook, Flickr, Instagram, Jamendo, LBRY, LiveLeak, Megaphone, Metacafe, Mixcloud, My&nbsp;Cloud&nbsp;Player, Overcast, PeerTube, Pippa, podCloud, PodMust, Pokémon&nbsp;TV, Radio, Radioline, Steam, Streamable, TikTok, Ultimedia, Veoh, VideoPress, Viously;
     <ul>
       <li>Germany: Arte;</li>
-      <li>Belgium: VRT&nbsp;NU;</li>
+      <li>Belgium: VRT&nbsp;NU, VTM&nbsp;GO;</li>
       <li>USA: KCAA&nbsp;Radio;</li>
-      <li>France: 20&nbsp;Minutes, AlloCiné, Arte, Arte&nbsp;Radio, France&nbsp;Inter, Futura Sciences, Gamekult, JeuxVideoCom, Konbini, Le&nbsp;Point, L'Internaute, Melty, Ouest-France;</li>
+      <li>France: 20&nbsp;Minutes, AlloCiné, Arte, Arte&nbsp;Radio, France&nbsp;Inter, Futura&nbsp;Sciences, Gamekult, JeuxVideoCom, Konbini, Le&nbsp;Point, L'Internaute, Melty, Ouest-France;</li>
       <li>Iran: آپارات;</li>
       <li>Iceland: Útvarp&nbsp;Saga;</li>
       <li>Netherlands: Dumpert;</li>

--- a/locales/fr/amo_description.html
+++ b/locales/fr/amo_description.html
@@ -7,13 +7,13 @@ Cast&nbsp;Kodi permet de diffuser des vidéos et des musiques sur <strong>Kodi</
     YouTube, Twitch, Vimeo, SoundCloud ainsi que Ace&nbsp;Stream, Apple&nbsp;Podcasts, Bigo&nbsp;Live, BitChute, Blog&nbsp;Talk&nbsp;Radio, Castbox, Dailymotion, DevTube, Facebook, Flickr, Instagram, Jamendo, LBRY, LiveLeak, Megaphone, Metacafe, Mixcloud, My&nbsp;Cloud&nbsp;Player, Overcast, PeerTube, Pippa, podCloud, PodMust, Pokémon&nbsp;TV, Radio, Radioline, Steam, Streamable, TikTok, Ultimedia, Veoh, VideoPress, Viously&nbsp;;
     <ul>
       <li>Allemagne&nbsp;: Arte&nbsp;;</li>
-      <li>Belgique&nbsp;: VRT NU&nbsp;;</li>
+      <li>Belgique&nbsp;: VRT&nbsp;NU&nbsp;, VTM&nbsp;GO&nbsp;;</li>
       <li>États-Unis&nbsp;: KCAA&nbsp;Radio&nbsp;;</li>
       <li>France&nbsp;: 20&nbsp;Minutes, AlloCiné, Arte, Arte&nbsp;Radio, France&nbsp;Inter, Futura&nbsp;Sciences, Gamekult, JeuxVideoCom, Konbini, Le&nbsp;Point, L'Internaute, Melty, Ouest-France&nbsp;;</li>
       <li>Iran&nbsp;: آپارات&nbsp;;</li>
       <li>Islande&nbsp;: Útvarp&nbsp;Saga&nbsp;;</li>
       <li>Pays-Bas&nbsp;: Dumpert&nbsp;;</li>
-      <li>Royaume-Uni&nbsp;: Daily&nbsp;Mail, The Guardian&nbsp;;</li>
+      <li>Royaume-Uni&nbsp;: Daily&nbsp;Mail, The&nbsp;Guardian&nbsp;;</li>
       <li>Russie&nbsp;: Первый&nbsp;канал.</li>
     </ul>
   </li>

--- a/locales/sk/amo_description.html
+++ b/locales/sk/amo_description.html
@@ -7,9 +7,9 @@ Cast&nbsp;Kodi, pridá možnosť posielania videí a hudby do <strong>Kodi</stro
     YouTube, Twitch, Vimeo, SoundCloud a tiež Ace&nbsp;Stream, Apple&nbsp;Podcasty, Bigo&nbsp;Live, BitChute, Blog&nbsp;Talk&nbsp;Radio, Castbox, Dailymotion, DevTube, Facebook, Flickr, Instagram, Jamendo, LBRY, LiveLeak, Megaphone, Metacafe, Mixcloud, My&nbsp;Cloud&nbsp;Player, Overcast, PeerTube, Pippa, podCloud, PodMust, Pokémon&nbsp;TV, Radio, Radioline, Steam, Streamable, TikTok, Ultimedia, Veoh, VideoPress, Viously;
     <ul>
       <li>Nemecko: Arte;</li>
-      <li>Belgicko: VRT&nbsp;NU;</li>
+      <li>Belgicko: VRT&nbsp;NU, VTM&nbsp;GO;</li>
       <li>USA: KCAA&nbsp;Radio;</li>
-      <li>Francúzsko: 20&nbsp;Minutes, AlloCiné, Arte, Arte&nbsp;Radio, France&nbsp;Inter, Futura Sciences, Gamekult, JeuxVideoCom, Konbini, Le&nbsp;Point, L'Internaute, Melty, Ouest-France;</li>
+      <li>Francúzsko: 20&nbsp;Minutes, AlloCiné, Arte, Arte&nbsp;Radio, France&nbsp;Inter, Futura&nbsp;Sciences, Gamekult, JeuxVideoCom, Konbini, Le&nbsp;Point, L'Internaute, Melty, Ouest-France;</li>
       <li>Irán: آپارات;</li>
       <li>Island: Útvarp&nbsp;Saga;</li>
       <li>Holandsko: Dumpert;</li>

--- a/src/core/labeller/vtmgo.js
+++ b/src/core/labeller/vtmgo.js
@@ -1,0 +1,51 @@
+/**
+ * @module
+ */
+/* eslint-disable require-await */
+
+import { matchPattern } from "../../tools/matchpattern.js";
+
+/**
+ * Extrait le titre d'un épisode ou d'un film de VTM GO.
+ *
+ * @param {URL} url L'URL utilisant le plugin de VTM GO.
+ * @returns {Promise<?string>} Une promesse contenant le titre ou
+ *                             <code>null</code>.
+ */
+const actionVideo = async function ({ pathname }) {
+    // Enlever le nom de domaine car un bogue dans Firefox le déplace dans le
+    // chemin. https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
+    const [type, uuid] = pathname.replace("//plugin.video.vtm.go", "")
+                                 .slice(14).split("/");
+    const response = await fetch("https://vtm.be/vtmgo/afspelen/" +
+                                                         type.charAt(0) + uuid);
+    const text = await response.text();
+    const doc = new DOMParser().parseFromString(text, "text/html");
+    return doc.querySelector("h1.player__title")?.textContent ?? null;
+};
+export const extractVideo = matchPattern(actionVideo,
+    "plugin://plugin.video.vtm.go/play/catalog/episodes/*",
+    "plugin://plugin.video.vtm.go/play/catalog/movies/*");
+
+/**
+ * Extrait le titre d'une chaine de VTM GO.
+ *
+ * @param {URL} url L'URL utilisant le plugin de VTM GO.
+ * @returns {Promise<?string>} Une promesse contenant le titre ou
+ *                             <code>null</code>.
+ */
+const actionChannel = async function ({ pathname }) {
+    // Enlever le nom de domaine car un bogue dans Firefox le déplace dans le
+    // chemin. https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
+    const uuid = pathname.replace("//plugin.video.vtm.go", "").slice(23);
+    const response = await fetch("https://vtm.be/vtmgo/live-kijken/vtm");
+    const text = await response.text();
+    const doc = new DOMParser().parseFromString(text, "text/html");
+    const a = doc.querySelector(`a[data-gtm*="/${uuid}/"]`);
+    if (null === a) {
+        return null;
+    }
+    return a.dataset.gtm.slice(a.dataset.gtm.lastIndexOf("/") + 1);
+};
+export const extractChannel = matchPattern(actionChannel,
+    "plugin://plugin.video.vtm.go/play/catalog/channels/*");

--- a/src/core/labellers.js
+++ b/src/core/labellers.js
@@ -8,6 +8,7 @@ import * as dumpert     from "./labeller/dumpert.js";
 import * as soundcloud  from "./labeller/soundcloud.js";
 import * as twitch      from "./labeller/twitch.js";
 import * as vimeo       from "./labeller/vimeo.js";
+import * as vtmgo       from "./labeller/vtmgo.js";
 import * as youtube     from "./labeller/youtube.js";
 /* eslint-enable import/no-namespace */
 import { strip } from "./sanitizer.js";
@@ -24,6 +25,7 @@ const LABELLERS = [
     soundcloud,
     twitch,
     vimeo,
+    vtmgo,
     youtube,
 ].flatMap((l) => Object.values(l));
 

--- a/src/core/scraper/vtmgo.js
+++ b/src/core/scraper/vtmgo.js
@@ -6,16 +6,16 @@
 import { matchPattern } from "../../tools/matchpattern.js";
 
 /**
- * L'URL de l'extension pour lire des vidéos issues de VRT NU.
+ * L'URL de l'extension pour lire des vidéos issues de VTM GO.
  *
  * @constant {string}
  */
 const PLUGIN_URL = "plugin://plugin.video.vtm.go/play/catalog/";
 
 /**
- * Extrait les informations nécessaire pour lire une vidéo sur Kodi.
+ * Extrait les informations nécessaire pour lire un épisode sur Kodi.
  *
- * @param {URL} url L'URL d'une vidéo VRT NU.
+ * @param {URL} url L'URL d'un épisode de VTM GO.
  * @returns {Promise<string>} Une promesse contenant le lien du
  *                            <em>fichier</em>.
  */
@@ -24,13 +24,13 @@ const actionEpisode = async function ({ pathname }) {
 };
 
 export const extractEpisode = matchPattern(actionEpisode,
-    "*://www.vtm.be/vtmgo/afspelen/e*",
-    "*://vtm.be/vtmgo/afspelen/e*");
+    "*://vtm.be/vtmgo/afspelen/e*",
+    "*://www.vtm.be/vtmgo/afspelen/e*");
 
 /**
- * Extrait les informations nécessaire pour lire une vidéo sur Kodi.
+ * Extrait les informations nécessaire pour lire un film sur Kodi.
  *
- * @param {URL} url L'URL d'une vidéo VRT NU.
+ * @param {URL} url L'URL d'un film de VTM GO.
  * @returns {Promise<string>} Une promesse contenant le lien du
  *                            <em>fichier</em>.
  */
@@ -39,13 +39,13 @@ const actionMovie = async function ({ pathname }) {
 };
 
 export const extractMovie = matchPattern(actionMovie,
-    "*://www.vtm.be/vtmgo/afspelen/m*",
-    "*://vtm.be/vtmgo/afspelen/m*");
+    "*://vtm.be/vtmgo/afspelen/m*",
+    "*://www.vtm.be/vtmgo/afspelen/m*");
 
 /**
- * Extrait les informations nécessaire pour lire une vidéo sur Kodi.
+ * Extrait les informations nécessaire pour lire un film sur Kodi.
  *
- * @param {URL} url L'URL d'une vidéo VRT NU.
+ * @param {URL} url L'URL d'une page d'un film de VTM GO.
  * @returns {Promise<string>} Une promesse contenant le lien du
  *                            <em>fichier</em>.
  */
@@ -54,25 +54,25 @@ const actionMoviePage = async function ({ pathname }) {
 };
 
 export const extractMoviePage = matchPattern(actionMoviePage,
-    "*://www.vtm.be/vtmgo/*~m*",
-    "*://vtm.be/vtmgo/*~m*");
+    "*://vtm.be/vtmgo/*~m*",
+    "*://www.vtm.be/vtmgo/*~m*");
 
 /**
- * Extrait les informations nécessaire pour lire une vidéo sur Kodi.
+ * Extrait les informations nécessaire pour lire une chaine sur Kodi.
  *
- * @param {URL} _url L'URL d'une vidéo VRT NU.
+ * @param {URL}      _url         L'URL d'une chaine VTM GO.
  * @param {Object}   content      Le contenu de l'URL.
  * @param {Function} content.html La fonction retournant la promesse contenant
  *                                le document HTML.
- * @returns {Promise<string>} Une promesse contenant le lien du
- *                            <em>fichier</em>.
+ * @returns {Promise<?string>} Une promesse contenant le lien du
+ *                             <em>fichier</em> ou <code>null</code>.
  */
-const actionLive = async function (_url, content) {
+const actionChannel = async function (_url, content) {
     const doc = await content.html();
     const div = doc.querySelector("div.fjs-player[data-id]");
     return null === div ? null
                         : PLUGIN_URL + "channels/" + div.dataset.id;
 };
-export const extractLive = matchPattern(actionLive,
-    "*://www.vtm.be/vtmgo/live-kijken/*",
-    "*://vtm.be/vtmgo/live-kijken/*");
+export const extractChannel = matchPattern(actionChannel,
+    "*://vtm.be/vtmgo/live-kijken/*",
+    "*://www.vtm.be/vtmgo/live-kijken/*");

--- a/src/core/scraper/vtmgo.js
+++ b/src/core/scraper/vtmgo.js
@@ -1,0 +1,71 @@
+/**
+ * @module
+ */
+
+import { matchPattern } from "../../tools/matchpattern.js";
+
+/**
+ * L'URL de l'extension pour lire des vidéos issues de VRT NU.
+ *
+ * @constant {string}
+ */
+const PLUGIN_URL = "plugin://plugin.video.vtm.go/play/catalog/";
+
+/**
+ * Extrait les informations nécessaire pour lire une vidéo sur Kodi.
+ *
+ * @param {URL} url L'URL d'une vidéo VRT NU.
+ * @param {Object}   content      Le contenu de l'URL.
+ * @param {Function} content.html La fonction retournant la promesse contenant
+ *                                le document HTML.
+ * @returns {Promise<string>} Une promesse contenant le lien du
+ *                            <em>fichier</em>.
+ */
+const action = async function ({ pathname }, content) {
+    const tryPathname = function () {
+        const categories = {
+            e: "episodes",
+            m: "movies",
+        };
+        const regex = /^\/vtmgo\/(?:afspelen\/|[^/]*~)([em])([\da-z-]+)$/u;
+        const matches = regex.exec(pathname);
+        if (null === matches) {
+            return null;
+        }
+        const [, categoryIdentifier, item] = matches;
+
+        return PLUGIN_URL + categories[categoryIdentifier] + "/" + item;
+    };
+    const tryContent = async function () {
+        if (null === content || undefined === content) {
+            return null;
+        }
+        const doc = await content.html();
+        if (null === doc) {
+            return null;
+        }
+
+        const playerDiv = doc.querySelector(".fjs-player");
+        if (null === playerDiv) {
+            return null;
+        }
+        let category = playerDiv.getAttribute("data-assettype");
+        if (null === category || "" === category) {
+            return null;
+        }
+        if ("s" !== category.slice(-1)) {
+            category += "s";
+        }
+        const item = playerDiv.getAttribute("data-id");
+
+        return PLUGIN_URL + category + "/" + item;
+    };
+    let returnValue = await tryContent();
+    if (null === returnValue) {
+        returnValue = tryPathname();
+    }
+    return returnValue;
+};
+export const extract = matchPattern(action,
+    "*://www.vtm.be/vtmgo/*",
+    "*://vtm.be/vtmgo/*");

--- a/src/core/scrapers.js
+++ b/src/core/scrapers.js
@@ -61,6 +61,7 @@ import * as vidlox         from "./scraper/vidlox.js";
 import * as vimeo          from "./scraper/vimeo.js";
 import * as viously        from "./scraper/viously.js";
 import * as vrtnu          from "./scraper/vrtnu.js";
+import * as vtmgo          from "./scraper/vtmgo.js";
 import * as youtube        from "./scraper/youtube.js";
 /* eslint-enable import/no-namespace */
 
@@ -115,6 +116,7 @@ const SCRAPERS = [
     vimeo,
     viously,
     vrtnu,
+    vtmgo,
     youtube,
     // Utiliser les scrapers génériques en dernier recours.
     video,

--- a/test/integration/scraper/vtmgo.js
+++ b/test/integration/scraper/vtmgo.js
@@ -1,0 +1,64 @@
+import assert      from "assert";
+import { extract } from "../../../src/core/scrapers.js";
+
+describe("Scraper: VTM GO", function () {
+
+    // Needs a consent and login
+    // it("should return video URL when format is live-kijken/<channelname>"
+    //   , async function () {
+    //     const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm");
+    //     const options = { depth: false, incognito: false };
+    //
+    //     const file = await extract(url, options);
+    //     assert.strictEqual(file,
+    //         "plugin://plugin.video.vtm.go/play/catalog/" +
+    //                                  "channels/" +
+    //                                  "d8659669-b964-414c-aa9c-e31d8d15696b");
+    // });
+
+    it("should return video URL when format is afspelen/<character><uuid>"
+      , async function () {
+        const url = new URL("https://www.vtm.be/vtmgo" +
+                             "/afspelen/e2bb78f60-e096-4ba3-8611-d5214f0f5d76");
+        const options = { depth: false, incognito: false };
+
+        const file = await extract(url, options);
+        assert.strictEqual(file,
+            "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "episodes/2bb78f60-e096-4ba3-8611-d5214f0f5d76");
+    });
+
+    it("should return video URL when format is <name>~<character><uuid>"
+      , async function () {
+        const url = new URL("https://www.vtm.be/vtmgo" +
+                        "/bowling-balls~m31b2acd3-1659-4ed0-885e-5f49999fbfdb");
+        const options = { depth: false, incognito: false };
+
+        const file = await extract(url, options);
+        assert.strictEqual(file,
+            "plugin://plugin.video.vtm.go/play/catalog/" +
+                                 "movies/31b2acd3-1659-4ed0-885e-5f49999fbfdb");
+    });
+
+    it("should return video URL when protocol is HTTP", async function () {
+        const url = new URL("http://www.vtm.be/vtmgo" +
+                             "/afspelen/m119e8927-e1c6-4764-b1ad-deaab1920427");
+        const options = { depth: false, incognito: false };
+
+        const file = await extract(url, options);
+        assert.strictEqual(file,
+            "plugin://plugin.video.vtm.go/play/catalog/" +
+                                 "movies/119e8927-e1c6-4764-b1ad-deaab1920427");
+    });
+
+    it("should return video URL without 'www'", async function () {
+        const url = new URL("https://vtm.be/vtmgo" +
+                  "/bang-van-dendoncker~m119e8927-e1c6-4764-b1ad-deaab1920427");
+        const options = { depth: false, incognito: false };
+
+        const file = await extract(url, options);
+        assert.strictEqual(file,
+            "plugin://plugin.video.vtm.go/play/catalog/" +
+                                 "movies/119e8927-e1c6-4764-b1ad-deaab1920427");
+    });
+});

--- a/test/integration/scraper/vtmgo.js
+++ b/test/integration/scraper/vtmgo.js
@@ -2,63 +2,36 @@ import assert      from "assert";
 import { extract } from "../../../src/core/scrapers.js";
 
 describe("Scraper: VTM GO", function () {
-
-    // Needs a consent and login
-    // it("should return video URL when format is live-kijken/<channelname>"
-    //   , async function () {
-    //     const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm");
-    //     const options = { depth: false, incognito: false };
-    //
-    //     const file = await extract(url, options);
-    //     assert.strictEqual(file,
-    //         "plugin://plugin.video.vtm.go/play/catalog/" +
-    //                                  "channels/" +
-    //                                  "d8659669-b964-414c-aa9c-e31d8d15696b");
-    // });
-
-    it("should return video URL when format is afspelen/<character><uuid>"
-      , async function () {
-        const url = new URL("https://www.vtm.be/vtmgo" +
-                             "/afspelen/e2bb78f60-e096-4ba3-8611-d5214f0f5d76");
+    it("should return video UUID from episode", async function () {
+        const url = new URL("https://vtm.be/vtmgo/afspelen" +
+                                      "/eb126a07d-ee7d-48a5-9bf5-b2eac8ced615");
         const options = { depth: false, incognito: false };
 
         const file = await extract(url, options);
         assert.strictEqual(file,
-            "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "episodes/2bb78f60-e096-4ba3-8611-d5214f0f5d76");
+            "plugin://plugin.video.vtm.go/play/catalog/episodes" +
+                                       "/b126a07d-ee7d-48a5-9bf5-b2eac8ced615");
     });
 
-    it("should return video URL when format is <name>~<character><uuid>"
-      , async function () {
-        const url = new URL("https://www.vtm.be/vtmgo" +
-                        "/bowling-balls~m31b2acd3-1659-4ed0-885e-5f49999fbfdb");
+    it("should return video UUID from movie", async function () {
+        const url = new URL("https://vtm.be/vtmgo/afspelen" +
+                                      "/m10d744fc-bf08-4ff0-9c54-f4a014789584");
         const options = { depth: false, incognito: false };
 
         const file = await extract(url, options);
         assert.strictEqual(file,
-            "plugin://plugin.video.vtm.go/play/catalog/" +
-                                 "movies/31b2acd3-1659-4ed0-885e-5f49999fbfdb");
+            "plugin://plugin.video.vtm.go/play/catalog/movies" +
+                                       "/10d744fc-bf08-4ff0-9c54-f4a014789584");
     });
 
-    it("should return video URL when protocol is HTTP", async function () {
-        const url = new URL("http://www.vtm.be/vtmgo" +
-                             "/afspelen/m119e8927-e1c6-4764-b1ad-deaab1920427");
-        const options = { depth: false, incognito: false };
-
-        const file = await extract(url, options);
-        assert.strictEqual(file,
-            "plugin://plugin.video.vtm.go/play/catalog/" +
-                                 "movies/119e8927-e1c6-4764-b1ad-deaab1920427");
-    });
-
-    it("should return video URL without 'www'", async function () {
+    it("should return video UUID from movie page", async function () {
         const url = new URL("https://vtm.be/vtmgo" +
-                  "/bang-van-dendoncker~m119e8927-e1c6-4764-b1ad-deaab1920427");
+                                "/pippa~m5566ccf0-9b9a-4e61-9d2f-3f2f4793ffde");
         const options = { depth: false, incognito: false };
 
         const file = await extract(url, options);
         assert.strictEqual(file,
-            "plugin://plugin.video.vtm.go/play/catalog/" +
-                                 "movies/119e8927-e1c6-4764-b1ad-deaab1920427");
+            "plugin://plugin.video.vtm.go/play/catalog/movies" +
+                                       "/5566ccf0-9b9a-4e61-9d2f-3f2f4793ffde");
     });
 });

--- a/test/unit/core/labeller/vtmgo.js
+++ b/test/unit/core/labeller/vtmgo.js
@@ -1,0 +1,139 @@
+import assert from "assert";
+import sinon  from "sinon";
+import { extractChannel, extractVideo }
+                                  from "../../../../src/core/labeller/vtmgo.js";
+
+describe("core/labeller/vtmgo.js", function () {
+    describe("extractVideo()", function () {
+        it("should return null when type is unknown", async function () {
+            const url = new URL("plugin://plugin.video.vtm.go/play/catalog" +
+                                                                        "/foo");
+
+            const label = await extractVideo(url);
+            assert.strictEqual(label, null);
+        });
+
+        it("should return episode label", async function () {
+            const stub = sinon.stub(globalThis, "fetch").resolves(new Response(
+                `<html>
+                   <body>
+                     <h1 class="player__title">foo</h1>
+                   </body>
+                 </html>`,
+            ));
+
+            const url = new URL("plugin://plugin.video.vtm.go/play/catalog" +
+                                                               "/episodes/bar");
+
+            const label = await extractVideo(url);
+            assert.strictEqual(label, "foo");
+
+            assert.strictEqual(stub.callCount, 1);
+            assert.deepStrictEqual(stub.firstCall.args, [
+                "https://vtm.be/vtmgo/afspelen/ebar",
+            ]);
+
+            stub.restore();
+        });
+
+        it("should return movie label", async function () {
+            const stub = sinon.stub(globalThis, "fetch").resolves(new Response(
+                `<html>
+                   <body>
+                     <h1 class="player__title">foo</h1>
+                   </body>
+                 </html>`,
+            ));
+
+            const url = new URL("plugin://plugin.video.vtm.go/play/catalog" +
+                                                                 "/movies/bar");
+
+            const label = await extractVideo(url);
+            assert.strictEqual(label, "foo");
+
+            assert.strictEqual(stub.callCount, 1);
+            assert.deepStrictEqual(stub.firstCall.args, [
+                "https://vtm.be/vtmgo/afspelen/mbar",
+            ]);
+
+            stub.restore();
+        });
+
+        it("should return null when there isn't title", async function () {
+            const stub = sinon.stub(globalThis, "fetch").resolves(new Response(
+                `<html>
+                   <body>
+                     <h1>foo</h1>
+                   </body>
+                 </html>`,
+            ));
+
+            const url = new URL("plugin://plugin.video.vtm.go/play/catalog" +
+                                                                 "/movies/bar");
+
+            const label = await extractVideo(url);
+            assert.strictEqual(label, null);
+
+            assert.strictEqual(stub.callCount, 1);
+            assert.deepStrictEqual(stub.firstCall.args, [
+                "https://vtm.be/vtmgo/afspelen/mbar",
+            ]);
+
+            stub.restore();
+        });
+    });
+
+    describe("extractChannel()", function () {
+        it("should return null when type is unknown", async function () {
+            const url = new URL("plugin://plugin.video.vtm.go/play/catalog" +
+                                                                        "/foo");
+
+            const label = await extractChannel(url);
+            assert.strictEqual(label, null);
+        });
+
+        it("should return channel label", async function () {
+            const stub = sinon.stub(globalThis, "fetch").resolves(new Response(
+                `<html>
+                   <body>
+                     <a data-gtm="foo/bar/baz">qux</a>
+                   </body>
+                 </html>`,
+            ));
+
+            const url = new URL("plugin://plugin.video.vtm.go/play/catalog" +
+                                                               "/channels/bar");
+
+            const label = await extractChannel(url);
+            assert.strictEqual(label, "baz");
+
+            assert.strictEqual(stub.callCount, 1);
+            assert.deepStrictEqual(stub.firstCall.args, [
+                "https://vtm.be/vtmgo/live-kijken/vtm",
+            ]);
+
+            stub.restore();
+        });
+
+        it("should return null when there isn't link", async function () {
+            const stub = sinon.stub(globalThis, "fetch").resolves(new Response(
+                `<html>
+                   <body></body>
+                 </html>`,
+            ));
+
+            const url = new URL("plugin://plugin.video.vtm.go/play/catalog" +
+                                                               "/channels/bar");
+
+            const label = await extractChannel(url);
+            assert.strictEqual(label, null);
+
+            assert.strictEqual(stub.callCount, 1);
+            assert.deepStrictEqual(stub.firstCall.args, [
+                "https://vtm.be/vtmgo/live-kijken/vtm",
+            ]);
+
+            stub.restore();
+        });
+    });
+});

--- a/test/unit/core/scraper/vtmgo.js
+++ b/test/unit/core/scraper/vtmgo.js
@@ -1,5 +1,5 @@
-import assert      from "assert";
-import { extractEpisode, extractLive, extractMovie, extractMoviePage }
+import assert from "assert";
+import { extractChannel, extractEpisode, extractMovie, extractMoviePage }
                                    from "../../../../src/core/scraper/vtmgo.js";
 
 describe("core/scraper/vtmgo.js", function () {
@@ -11,25 +11,20 @@ describe("core/scraper/vtmgo.js", function () {
             assert.strictEqual(file, null);
         });
 
-        it("should return video URL when format is afspelen/<character><uuid>",
-                                                             async function () {
-            const url = new URL("http://www.vtm.be/vtmgo/" +
-                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        it("should return video UUID", async function () {
+            const url = new URL("http://vtm.be/vtmgo/afspelen/efoo");
 
             const file = await extractEpisode(url);
             assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+                "plugin://plugin.video.vtm.go/play/catalog/episodes/foo");
         });
 
-        it("should return video URL without 'www'", async function () {
-            const url = new URL("http://vtm.be/vtmgo/" +
-                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        it("should return video UUID with 'www'", async function () {
+            const url = new URL("http://www.vtm.be/vtmgo/afspelen/efoo");
 
             const file = await extractEpisode(url);
             assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+                "plugin://plugin.video.vtm.go/play/catalog/episodes/foo");
         });
     });
 
@@ -41,25 +36,20 @@ describe("core/scraper/vtmgo.js", function () {
             assert.strictEqual(file, null);
         });
 
-        it("should return video URL when format is afspelen/<character><uuid>",
-                                                             async function () {
-            const url = new URL("http://www.vtm.be/vtmgo/" +
-                              "afspelen/m97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        it("should return video UUID", async function () {
+            const url = new URL("http://vtm.be/vtmgo/afspelen/mfoo");
 
             const file = await extractMovie(url);
             assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "movies/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+                "plugin://plugin.video.vtm.go/play/catalog/movies/foo");
         });
 
-        it("should return video URL without 'www'", async function () {
-            const url = new URL("http://vtm.be/vtmgo/" +
-                              "afspelen/m97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        it("should return video UUID with 'www'", async function () {
+            const url = new URL("http://www.vtm.be/vtmgo/afspelen/mfoo");
 
             const file = await extractMovie(url);
             assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "movies/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+                "plugin://plugin.video.vtm.go/play/catalog/movies/foo");
         });
     });
 
@@ -71,29 +61,33 @@ describe("core/scraper/vtmgo.js", function () {
             assert.strictEqual(file, null);
         });
 
-        it("should return video URL when format is <name>~<character><uuid>",
-                                                             async function () {
-            const url = new URL("https://vtm.be/vtmgo/" +
-                                   "foo~m97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        it("should return video UUID", async function () {
+            const url = new URL("https://vtm.be/vtmgo/foo~mbar");
 
             const file = await extractMoviePage(url);
             assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                                 "movies/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+                "plugin://plugin.video.vtm.go/play/catalog/movies/bar");
+        });
+
+        it("should return video UUID with 'www'", async function () {
+            const url = new URL("https://www.vtm.be/vtmgo/foo~mbar");
+
+            const file = await extractMoviePage(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/movies/bar");
         });
     });
 
-    describe("extractLive()", function () {
+    describe("extractChannel()", function () {
         it("should return null when it's a unsupported URL", async function () {
             const url = new URL("https://foo.be");
 
-            const file = await extractLive(url);
+            const file = await extractChannel(url);
             assert.strictEqual(file, null);
         });
 
-        it("should return null without fjs-player and url without id",
-                                                             async function () {
-            const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm");
+        it("should return null when there isn't player", async function () {
+            const url = new URL("https://vtm.be/vtmgo/live-kijken/foo");
             const content = {
                 html: () => Promise.resolve(new DOMParser().parseFromString(`
                     <html>
@@ -101,27 +95,24 @@ describe("core/scraper/vtmgo.js", function () {
                     </html>`, "text/html")),
             };
 
-            const file = await extractLive(url, content);
+            const file = await extractChannel(url, content);
             assert.strictEqual(file, null);
         });
 
-        it("should return video URL from live content", async function () {
-            const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm3");
+        it("should return video UUID", async function () {
+            const url = new URL("https://vtm.be/vtmgo/live-kijken/foo");
             const content = {
                 html: () => Promise.resolve(new DOMParser().parseFromString(`
                     <html>
                       <body>
-                        <div class="fjs-player" data-assettype="channel"
-                                 data-id="d9a8ca31-850d-4536-87e8-d4928ce5ec6e">
-                        </div>
+                        <div class="fjs-player" data-id="bar"></div>
                       </body>
                     </html>`, "text/html")),
             };
 
-            const file = await extractLive(url, content);
+            const file = await extractChannel(url, content);
             assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "channels/d9a8ca31-850d-4536-87e8-d4928ce5ec6e");
+                "plugin://plugin.video.vtm.go/play/catalog/channels/bar");
         });
     });
 });

--- a/test/unit/core/scraper/vtmgo.js
+++ b/test/unit/core/scraper/vtmgo.js
@@ -1,0 +1,158 @@
+import assert      from "assert";
+import { extract } from "../../../../src/core/scraper/vtmgo.js";
+
+describe("core/scraper/vtmgo.js", function () {
+    describe("extract()", function () {
+        it("should return null when it's a unsupported URL", async function () {
+            const url = new URL("https://foo.be");
+
+            const file = await extract(url);
+            assert.strictEqual(file, null);
+        });
+
+        it("should return null with an unsupported vtm URL and bad contents"
+            , async function () {
+            const url = new URL("https://vtm.be/vtmgo/" +
+                                   "foo~p97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extract(url);
+            assert.strictEqual(file, null);
+        });
+
+        it("should return null when it's not a HTML page and url without id",
+            async function () {
+            const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm2");
+            const content = { html: () => Promise.resolve(null) };
+
+            const file = await extract(url, content);
+            assert.strictEqual(file, null);
+        });
+
+        it("should return null without fjs-player and url without id",
+            async function () {
+            const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm");
+            const content = {
+                html: () => Promise.resolve(new DOMParser().parseFromString(`
+                    <html>
+                      <body></body>
+                    </html>`, "text/html")),
+            };
+
+            const file = await extract(url, content);
+            assert.strictEqual(file, null);
+        });
+
+        it("should return null when id is not set", async function () {
+            const url = new URL("https://vtm.be/vtmgo/foo");
+            const content = {
+                html: () => Promise.resolve(new DOMParser().parseFromString(`
+                    <html>
+                      <body>
+                        <div class="fjs-player" data-assettype="">
+                        </div>
+                      </body>
+                    </html>`, "text/html")),
+            };
+
+            const file = await extract(url, content);
+            assert.strictEqual(file, null);
+        });
+
+        it("should return null when assettype is empty", async function () {
+            const url = new URL("https://vtm.be/vtmgo/foo");
+            const content = {
+                html: () => Promise.resolve(new DOMParser().parseFromString(`
+                    <html>
+                      <body>
+                        <div class="fjs-player" data-assettype=""
+                                 data-id="d9a8ca31-850d-4536-87e8-d4928ce5ec6e">
+                        </div>
+                      </body>
+                    </html>`, "text/html")),
+            };
+
+            const file = await extract(url, content);
+            assert.strictEqual(file, null);
+        });
+
+        it("should return video URL from episodes content", async function () {
+            const url = new URL("https://vtm.be/vtmgo/foo");
+            const content = {
+                html: () => Promise.resolve(new DOMParser().parseFromString(`
+                    <html>
+                      <body>
+                        <div class="fjs-player" data-assettype="episodes"
+                                 data-id="d9a8ca31-850d-4536-87e8-d4928ce5ec6e">
+                        </div>
+                      </body>
+                    </html>`, "text/html")),
+            };
+
+            const file = await extract(url, content);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "episodes/d9a8ca31-850d-4536-87e8-d4928ce5ec6e");
+        });
+
+        it("should return video URL from live content", async function () {
+            const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm3");
+            const content = {
+                html: () => Promise.resolve(new DOMParser().parseFromString(`
+                    <html>
+                      <body>
+                        <div class="fjs-player" data-assettype="channel"
+                                 data-id="d9a8ca31-850d-4536-87e8-d4928ce5ec6e">
+                        </div>
+                      </body>
+                    </html>`, "text/html")),
+            };
+
+            const file = await extract(url, content);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "channels/d9a8ca31-850d-4536-87e8-d4928ce5ec6e");
+        });
+
+        it("should return video URL when format is afspelen/<character><uuid>"
+            , async function () {
+            const url = new URL("https://www.vtm.be/vtmgo/" +
+                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extract(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        });
+
+        it("should return video URL when format is <name>~<character><uuid>"
+            , async function () {
+            const url = new URL("https://vtm.be/vtmgo/" +
+                                   "foo~m97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extract(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                                 "movies/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        });
+
+        it("should return video URL when protocol is HTTP", async function () {
+            const url = new URL("http://www.vtm.be/vtmgo/" +
+                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extract(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        });
+
+        it("should return video URL without 'www'", async function () {
+            const url = new URL("http://vtm.be/vtmgo/" +
+                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extract(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        });
+    });
+});

--- a/test/unit/core/scraper/vtmgo.js
+++ b/test/unit/core/scraper/vtmgo.js
@@ -1,35 +1,98 @@
 import assert      from "assert";
-import { extract } from "../../../../src/core/scraper/vtmgo.js";
+import { extractEpisode, extractLive, extractMovie, extractMoviePage }
+                                   from "../../../../src/core/scraper/vtmgo.js";
 
 describe("core/scraper/vtmgo.js", function () {
-    describe("extract()", function () {
+    describe("extractEpisode()", function () {
         it("should return null when it's a unsupported URL", async function () {
             const url = new URL("https://foo.be");
 
-            const file = await extract(url);
+            const file = await extractEpisode(url);
             assert.strictEqual(file, null);
         });
 
-        it("should return null with an unsupported vtm URL and bad contents"
-            , async function () {
+        it("should return video URL when format is afspelen/<character><uuid>",
+                                                             async function () {
+            const url = new URL("http://www.vtm.be/vtmgo/" +
+                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extractEpisode(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        });
+
+        it("should return video URL without 'www'", async function () {
+            const url = new URL("http://vtm.be/vtmgo/" +
+                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extractEpisode(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        });
+    });
+
+    describe("extractMovie()", function () {
+        it("should return null when it's a unsupported URL", async function () {
+            const url = new URL("https://foo.be");
+
+            const file = await extractMovie(url);
+            assert.strictEqual(file, null);
+        });
+
+        it("should return video URL when format is afspelen/<character><uuid>",
+                                                             async function () {
+            const url = new URL("http://www.vtm.be/vtmgo/" +
+                              "afspelen/m97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extractMovie(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "movies/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        });
+
+        it("should return video URL without 'www'", async function () {
+            const url = new URL("http://vtm.be/vtmgo/" +
+                              "afspelen/m97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+
+            const file = await extractMovie(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                               "movies/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+        });
+    });
+
+    describe("extractMoviePage()", function () {
+        it("should return null when it's a unsupported URL", async function () {
+            const url = new URL("https://foo.be");
+
+            const file = await extractMoviePage(url);
+            assert.strictEqual(file, null);
+        });
+
+        it("should return video URL when format is <name>~<character><uuid>",
+                                                             async function () {
             const url = new URL("https://vtm.be/vtmgo/" +
-                                   "foo~p97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
+                                   "foo~m97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
 
-            const file = await extract(url);
-            assert.strictEqual(file, null);
+            const file = await extractMoviePage(url);
+            assert.strictEqual(file,
+                "plugin://plugin.video.vtm.go/play/catalog/" +
+                                 "movies/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
         });
+    });
 
-        it("should return null when it's not a HTML page and url without id",
-            async function () {
-            const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm2");
-            const content = { html: () => Promise.resolve(null) };
+    describe("extractLive()", function () {
+        it("should return null when it's a unsupported URL", async function () {
+            const url = new URL("https://foo.be");
 
-            const file = await extract(url, content);
+            const file = await extractLive(url);
             assert.strictEqual(file, null);
         });
 
         it("should return null without fjs-player and url without id",
-            async function () {
+                                                             async function () {
             const url = new URL("https://vtm.be/vtmgo/live-kijken/vtm");
             const content = {
                 html: () => Promise.resolve(new DOMParser().parseFromString(`
@@ -38,60 +101,8 @@ describe("core/scraper/vtmgo.js", function () {
                     </html>`, "text/html")),
             };
 
-            const file = await extract(url, content);
+            const file = await extractLive(url, content);
             assert.strictEqual(file, null);
-        });
-
-        it("should return null when id is not set", async function () {
-            const url = new URL("https://vtm.be/vtmgo/foo");
-            const content = {
-                html: () => Promise.resolve(new DOMParser().parseFromString(`
-                    <html>
-                      <body>
-                        <div class="fjs-player" data-assettype="">
-                        </div>
-                      </body>
-                    </html>`, "text/html")),
-            };
-
-            const file = await extract(url, content);
-            assert.strictEqual(file, null);
-        });
-
-        it("should return null when assettype is empty", async function () {
-            const url = new URL("https://vtm.be/vtmgo/foo");
-            const content = {
-                html: () => Promise.resolve(new DOMParser().parseFromString(`
-                    <html>
-                      <body>
-                        <div class="fjs-player" data-assettype=""
-                                 data-id="d9a8ca31-850d-4536-87e8-d4928ce5ec6e">
-                        </div>
-                      </body>
-                    </html>`, "text/html")),
-            };
-
-            const file = await extract(url, content);
-            assert.strictEqual(file, null);
-        });
-
-        it("should return video URL from episodes content", async function () {
-            const url = new URL("https://vtm.be/vtmgo/foo");
-            const content = {
-                html: () => Promise.resolve(new DOMParser().parseFromString(`
-                    <html>
-                      <body>
-                        <div class="fjs-player" data-assettype="episodes"
-                                 data-id="d9a8ca31-850d-4536-87e8-d4928ce5ec6e">
-                        </div>
-                      </body>
-                    </html>`, "text/html")),
-            };
-
-            const file = await extract(url, content);
-            assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "episodes/d9a8ca31-850d-4536-87e8-d4928ce5ec6e");
         });
 
         it("should return video URL from live content", async function () {
@@ -107,52 +118,10 @@ describe("core/scraper/vtmgo.js", function () {
                     </html>`, "text/html")),
             };
 
-            const file = await extract(url, content);
+            const file = await extractLive(url, content);
             assert.strictEqual(file,
                 "plugin://plugin.video.vtm.go/play/catalog/" +
                                "channels/d9a8ca31-850d-4536-87e8-d4928ce5ec6e");
-        });
-
-        it("should return video URL when format is afspelen/<character><uuid>"
-            , async function () {
-            const url = new URL("https://www.vtm.be/vtmgo/" +
-                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
-
-            const file = await extract(url);
-            assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
-        });
-
-        it("should return video URL when format is <name>~<character><uuid>"
-            , async function () {
-            const url = new URL("https://vtm.be/vtmgo/" +
-                                   "foo~m97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
-
-            const file = await extract(url);
-            assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                                 "movies/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
-        });
-
-        it("should return video URL when protocol is HTTP", async function () {
-            const url = new URL("http://www.vtm.be/vtmgo/" +
-                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
-
-            const file = await extract(url);
-            assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
-        });
-
-        it("should return video URL without 'www'", async function () {
-            const url = new URL("http://vtm.be/vtmgo/" +
-                              "afspelen/e97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
-
-            const file = await extract(url);
-            assert.strictEqual(file,
-                "plugin://plugin.video.vtm.go/play/catalog/" +
-                               "episodes/97f7cf4a-1cb8-4564-a6e5-ee1f94052574");
         });
     });
 });


### PR DESCRIPTION
This PR adds support for VTM GO, a commercial belgian video platform.
To play the videos the [kodi plugin for VTM GO](https://kodi.tv/addon/plugins-video-add-ons/vtm-go) must be installed. For most videos, a login is required. They may also be geo-locked.
This PR is tested with the latest version (1.1.2) of the VTM GO plugin.