### PR TITLE
Proof-of-concept to fix issue #26

### DIFF
--- a/src/background/clearcookies.js
+++ b/src/background/clearcookies.js
@@ -1,0 +1,15 @@
+const removeCookies = function (details) {
+  for (let i = 0; i < details.requestHeaders.length; i++) {
+    const header = details.requestHeaders[i];
+    if ("cookie" === header.name.toLowerCase()) {
+      details.requestHeaders.splice(i, 1);
+    }
+  }
+  return { requestHeaders: details.requestHeaders };
+};
+
+browser.webRequest.onBeforeSendHeaders.addListener(
+  removeCookies,
+  { urls: ["ws://*/jsonrpc", "ws://*/jsonrpc?*"] },
+  ["blocking", "requestHeaders"],
+);

--- a/src/background/index.html
+++ b/src/background/index.html
@@ -9,5 +9,6 @@
     <script src="migrate.js" type="module"></script>
     <script src="menu.js" type="module"></script>
     <script src="permissions.js" type="module"></script>
+    <script src="clearcookies.js" type="module"></script>
   </body>
 </html>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -45,6 +45,8 @@
         "activeTab",
         "menus",
         "notifications",
-        "storage"
+        "storage",
+        "webRequest",
+        "webRequestBlocking"
     ]
 }


### PR DESCRIPTION
This fixes the issue described in #26 by removing the cookies using a webRequest listener.

side-effects:
* the good: it also fixes the same problems for similar add-ons
* the ugly: we remove the cookies for all web service requests
* the bad: if there is anything requiring those cookies, it won't work

work to be done:
* the listener filter should filter only the configured kodi hosts (and take configuration changes into account) -> be my guest
* maybe also identify the request made by this addon (details.documentUrl & originUrl == "moz-extension://<add-on (temporary) id>/popup/index.html" may be something usable)

Qu'est-ce que vous en pensez? Si vous voulez, vous pouvez l'utiliser et l'adapter comme vous voulez.