### PR TITLE
no age shaming

### DIFF
--- a/src/manifest-chromium.json
+++ b/src/manifest-chromium.json
@@ -2,7 +2,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "castkodi@regseb.github.io",
-      "strict_min_version": "117.0"
+      "strict_min_version": "1"
     }
   },
   "manifest_version": 3,
@@ -43,7 +43,7 @@
   },
   "homepage_url": "https://github.com/regseb/castkodi",
   "host_permissions": ["<all_urls>"],
-  "minimum_chrome_version": "116",
+  "minimum_chrome_version": "1",
   "optional_permissions": ["bookmarks", "clipboardRead", "history"],
   "options_ui": {
     "browser_style": false,


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)