### PR TITLE
Emulate button press instead of fixed input

### DIFF
--- a/src/core/jsonrpc/input.js
+++ b/src/core/jsonrpc/input.js
@@ -51,24 +51,26 @@ export const Input = class {
     }
 
     /**
+     * Envoie un évènement d'un bouton.
+     *
+     * @param {string}                    button   La clé du bouton.
+     * @param {"KB" | "XG" | "R1" | "R2"} [keymap] Le type du périphérique
+     *                                             (clavier, manette XBox,
+     *                                             télécommande standard,
+     *                                             télécommande universelle).
+     * @returns {Promise<string>} Une promesse contenant `"OK"`.
+     */
+    buttonEvent(button, keymap = "KB") {
+        return this.#kodi.send("Input.ButtonEvent", { button, keymap });
+    }
+
+    /**
      * Affiche le menu contextuel.
      *
      * @returns {Promise<string>} Une promesse contenant `"OK"`.
      */
     contextMenu() {
         return this.#kodi.send("Input.ContextMenu");
-    }
-
-    /**
-     * Navigue vers le bas dans l'interface.
-     *
-     * @returns {Promise<string>} Une promesse contenant `"OK"`.
-     */
-    down() {
-        return this.#kodi.send("Input.ButtonEvent", {
-            button: "down",
-            keymap: "KB",
-        });
     }
 
     /**
@@ -87,30 +89,6 @@ export const Input = class {
      */
     info() {
         return this.#kodi.send("Input.Info");
-    }
-
-    /**
-     * Navigue vers la gauche dans l'interface.
-     *
-     * @returns {Promise<string>} Une promesse contenant `"OK"`.
-     */
-    left() {
-        return this.#kodi.send("Input.ButtonEvent", {
-            button: "left",
-            keymap: "KB",
-        });
-    }
-
-    /**
-     * Navigue vers la droite dans l'interface.
-     *
-     * @returns {Promise<string>} Une promesse contenant `"OK"`.
-     */
-    right() {
-        return this.#kodi.send("Input.ButtonEvent", {
-            button: "right",
-            keymap: "KB",
-        });
     }
 
     /**
@@ -150,18 +128,6 @@ export const Input = class {
      */
     showPlayerProcessInfo() {
         return this.#kodi.send("Input.ShowPlayerProcessInfo");
-    }
-
-    /**
-     * Navigue vers le haut dans l'interface.
-     *
-     * @returns {Promise<string>} Une promesse contenant `"OK"`.
-     */
-    up() {
-        return this.#kodi.send("Input.ButtonEvent", {
-            button: "up",
-            keymap: "KB",
-        });
     }
 
     /**

--- a/src/core/jsonrpc/input.js
+++ b/src/core/jsonrpc/input.js
@@ -65,7 +65,10 @@ export const Input = class {
      * @returns {Promise<string>} Une promesse contenant `"OK"`.
      */
     down() {
-        return this.#kodi.send("Input.Down");
+        return this.#kodi.send("Input.ButtonEvent", {
+            button: "down",
+            keymap: "KB",
+        });
     }
 
     /**
@@ -92,7 +95,10 @@ export const Input = class {
      * @returns {Promise<string>} Une promesse contenant `"OK"`.
      */
     left() {
-        return this.#kodi.send("Input.Left");
+        return this.#kodi.send("Input.ButtonEvent", {
+            button: "left",
+            keymap: "KB",
+        });
     }
 
     /**
@@ -101,7 +107,10 @@ export const Input = class {
      * @returns {Promise<string>} Une promesse contenant `"OK"`.
      */
     right() {
-        return this.#kodi.send("Input.Right");
+        return this.#kodi.send("Input.ButtonEvent", {
+            button: "right",
+            keymap: "KB",
+        });
     }
 
     /**
@@ -149,7 +158,10 @@ export const Input = class {
      * @returns {Promise<string>} Une promesse contenant `"OK"`.
      */
     up() {
-        return this.#kodi.send("Input.Up");
+        return this.#kodi.send("Input.ButtonEvent", {
+            button: "up",
+            keymap: "KB",
+        });
     }
 
     /**

--- a/src/popup/script.js
+++ b/src/popup/script.js
@@ -327,7 +327,7 @@ const up = async () => {
     }
 
     try {
-        await kodi.input.up();
+        await kodi.input.buttonEvent("up");
     } catch (err) {
         openError(err);
     }
@@ -355,7 +355,7 @@ const left = async () => {
     }
 
     try {
-        await kodi.input.left();
+        await kodi.input.buttonEvent("left");
     } catch (err) {
         openError(err);
     }
@@ -383,7 +383,7 @@ const right = async () => {
     }
 
     try {
-        await kodi.input.right();
+        await kodi.input.buttonEvent("right");
     } catch (err) {
         openError(err);
     }
@@ -411,7 +411,7 @@ const down = async () => {
     }
 
     try {
-        await kodi.input.down();
+        await kodi.input.buttonEvent("down");
     } catch (err) {
         openError(err);
     }

--- a/test/unit/core/jsonrpc/input.test.js
+++ b/test/unit/core/jsonrpc/input.test.js
@@ -29,6 +29,38 @@ describe("core/jsonrpc/input.js", () => {
         });
     });
 
+    describe("buttonEvent()", () => {
+        it("should send request", async () => {
+            const kodi = new Kodi();
+            const send = mock.method(kodi, "send", () => Promise.resolve("OK"));
+
+            const input = new Input(kodi);
+            const result = await input.buttonEvent("foo");
+            assert.equal(result, "OK");
+
+            assert.equal(send.mock.callCount(), 1);
+            assert.deepEqual(send.mock.calls[0].arguments, [
+                "Input.ButtonEvent",
+                { button: "foo", keymap: "KB" },
+            ]);
+        });
+
+        it("should send request with keymap", async () => {
+            const kodi = new Kodi();
+            const send = mock.method(kodi, "send", () => Promise.resolve("OK"));
+
+            const input = new Input(kodi);
+            const result = await input.buttonEvent("foo", "R2");
+            assert.equal(result, "OK");
+
+            assert.equal(send.mock.callCount(), 1);
+            assert.deepEqual(send.mock.calls[0].arguments, [
+                "Input.ButtonEvent",
+                { button: "foo", keymap: "R2" },
+            ]);
+        });
+    });
+
     describe("contextMenu()", () => {
         it("should send request", async () => {
             const kodi = new Kodi();
@@ -41,23 +73,6 @@ describe("core/jsonrpc/input.js", () => {
             assert.equal(send.mock.callCount(), 1);
             assert.deepEqual(send.mock.calls[0].arguments, [
                 "Input.ContextMenu",
-            ]);
-        });
-    });
-
-    describe("down()", () => {
-        it("should send request", async () => {
-            const kodi = new Kodi();
-            const send = mock.method(kodi, "send", () => Promise.resolve("OK"));
-
-            const input = new Input(kodi);
-            const result = await input.down();
-            assert.equal(result, "OK");
-
-            assert.equal(send.mock.callCount(), 1);
-            assert.deepEqual(send.mock.calls[0].arguments, [
-                "Input.ButtonEvent",
-                { button: "down", keymap: "KB" },
             ]);
         });
     });
@@ -87,40 +102,6 @@ describe("core/jsonrpc/input.js", () => {
 
             assert.equal(send.mock.callCount(), 1);
             assert.deepEqual(send.mock.calls[0].arguments, ["Input.Info"]);
-        });
-    });
-
-    describe("left()", () => {
-        it("should send request", async () => {
-            const kodi = new Kodi();
-            const send = mock.method(kodi, "send", () => Promise.resolve("OK"));
-
-            const input = new Input(kodi);
-            const result = await input.left();
-            assert.equal(result, "OK");
-
-            assert.equal(send.mock.callCount(), 1);
-            assert.deepEqual(send.mock.calls[0].arguments, [
-                "Input.ButtonEvent",
-                { button: "left", keymap: "KB" },
-            ]);
-        });
-    });
-
-    describe("right()", () => {
-        it("should send request", async () => {
-            const kodi = new Kodi();
-            const send = mock.method(kodi, "send", () => Promise.resolve("OK"));
-
-            const input = new Input(kodi);
-            const result = await input.right();
-            assert.equal(result, "OK");
-
-            assert.equal(send.mock.callCount(), 1);
-            assert.deepEqual(send.mock.calls[0].arguments, [
-                "Input.ButtonEvent",
-                { button: "right", keymap: "KB" },
-            ]);
         });
     });
 
@@ -196,23 +177,6 @@ describe("core/jsonrpc/input.js", () => {
             assert.equal(send.mock.callCount(), 1);
             assert.deepEqual(send.mock.calls[0].arguments, [
                 "Input.ShowPlayerProcessInfo",
-            ]);
-        });
-    });
-
-    describe("up()", () => {
-        it("should send request", async () => {
-            const kodi = new Kodi();
-            const send = mock.method(kodi, "send", () => Promise.resolve("OK"));
-
-            const input = new Input(kodi);
-            const result = await input.up();
-            assert.equal(result, "OK");
-
-            assert.equal(send.mock.callCount(), 1);
-            assert.deepEqual(send.mock.calls[0].arguments, [
-                "Input.ButtonEvent",
-                { button: "up", keymap: "KB" },
             ]);
         });
     });

--- a/test/unit/core/jsonrpc/input.test.js
+++ b/test/unit/core/jsonrpc/input.test.js
@@ -55,7 +55,10 @@ describe("core/jsonrpc/input.js", () => {
             assert.equal(result, "OK");
 
             assert.equal(send.mock.callCount(), 1);
-            assert.deepEqual(send.mock.calls[0].arguments, ["Input.Down"]);
+            assert.deepEqual(send.mock.calls[0].arguments, [
+                "Input.ButtonEvent",
+                { button: "down", keymap: "KB" },
+            ]);
         });
     });
 
@@ -97,7 +100,10 @@ describe("core/jsonrpc/input.js", () => {
             assert.equal(result, "OK");
 
             assert.equal(send.mock.callCount(), 1);
-            assert.deepEqual(send.mock.calls[0].arguments, ["Input.Left"]);
+            assert.deepEqual(send.mock.calls[0].arguments, [
+                "Input.ButtonEvent",
+                { button: "left", keymap: "KB" },
+            ]);
         });
     });
 
@@ -111,7 +117,10 @@ describe("core/jsonrpc/input.js", () => {
             assert.equal(result, "OK");
 
             assert.equal(send.mock.callCount(), 1);
-            assert.deepEqual(send.mock.calls[0].arguments, ["Input.Right"]);
+            assert.deepEqual(send.mock.calls[0].arguments, [
+                "Input.ButtonEvent",
+                { button: "right", keymap: "KB" },
+            ]);
         });
     });
 
@@ -201,7 +210,10 @@ describe("core/jsonrpc/input.js", () => {
             assert.equal(result, "OK");
 
             assert.equal(send.mock.callCount(), 1);
-            assert.deepEqual(send.mock.calls[0].arguments, ["Input.Up"]);
+            assert.deepEqual(send.mock.calls[0].arguments, [
+                "Input.ButtonEvent",
+                { button: "up", keymap: "KB" },
+            ]);
         });
     });
 


### PR DESCRIPTION
When using Kodi with a physical keyboard, the arrow keys normally allow quick seeking during playback, but with the way this extension currently sends input, that functionality doesn’t work.

https://github.com/xbmc/xbmc/blob/master/system/keymaps/keyboard.xml#L375